### PR TITLE
feat: add variable.builtin highlighting and Go query embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ pip install tree-sitter-batch
 import tree_sitter_batch "github.com/wharflab/tree-sitter-batch/bindings/go"
 ```
 
+The root package also exports the bundled `queries/highlights.scm` via `go:embed`:
+
+```go
+import batch "github.com/wharflab/tree-sitter-batch"
+
+lang := batch.GetLanguage()
+query, _ := batch.GetHighlightsQuery()
+// or access the raw .scm source:
+// raw := batch.HighlightsQuery
+```
+
 ## Usage
 
 ### Node.js

--- a/queries.go
+++ b/queries.go
@@ -1,0 +1,21 @@
+package tree_sitter_batch
+
+import (
+	_ "embed"
+
+	binding "github.com/wharflab/tree-sitter-batch/bindings/go"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+//go:embed queries/highlights.scm
+var HighlightsQuery string
+
+// GetLanguage returns the tree-sitter Language for Batch.
+func GetLanguage() *sitter.Language {
+	return sitter.NewLanguage(binding.Language())
+}
+
+// GetHighlightsQuery compiles and returns the bundled highlights query.
+func GetHighlightsQuery() (*sitter.Query, *sitter.QueryError) {
+	return sitter.NewQuery(GetLanguage(), HighlightsQuery)
+}

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -31,7 +31,7 @@
 
 ; CMD pseudo/dynamic environment variables
 ((variable_reference) @variable.builtin
-  (#match? @variable.builtin "^%(CD|ERRORLEVEL|DATE|TIME|RANDOM|CMDCMDLINE|CMDEXTVERSION|HIGHESTNUMANODENUMBER|__APPDIR__|__CD__)%$"))
+  (#match? @variable.builtin "(?i)^[%!](CD|ERRORLEVEL|DATE|TIME|RANDOM|CMDCMDLINE|CMDEXTVERSION|HIGHESTNUMANODENUMBER|__APPDIR__|__CD__)[%!]$"))
 
 ; Variables
 (variable_reference) @variable

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -29,6 +29,10 @@
 ; Commands
 (command_name) @function
 
+; CMD pseudo/dynamic environment variables
+((variable_reference) @variable.builtin
+  (#match? @variable.builtin "^%(CD|ERRORLEVEL|DATE|TIME|RANDOM|CMDCMDLINE|CMDEXTVERSION|HIGHESTNUMANODENUMBER|__APPDIR__|__CD__)%$"))
+
 ; Variables
 (variable_reference) @variable
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -1,0 +1,35 @@
+package tree_sitter_batch_test
+
+import (
+	"testing"
+
+	batch "github.com/wharflab/tree-sitter-batch"
+)
+
+func TestHighlightsQueryCompiles(t *testing.T) {
+	if batch.HighlightsQuery == "" {
+		t.Fatal("HighlightsQuery is empty")
+	}
+	query, err := batch.GetHighlightsQuery()
+	if err != nil {
+		t.Fatalf("highlights query failed to compile: %v", err)
+	}
+	defer query.Close()
+
+	names := query.CaptureNames()
+	if len(names) == 0 {
+		t.Fatal("highlights query has no captures")
+	}
+
+	// Verify variable.builtin capture exists
+	found := false
+	for _, name := range names {
+		if name == "variable.builtin" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected variable.builtin capture, got: %v", names)
+	}
+}


### PR DESCRIPTION
## Summary
- Highlight CMD pseudo/dynamic environment variables (`%ERRORLEVEL%`, `%CD%`, `%DATE%`, `%TIME%`, `%RANDOM%`, etc.) as `@variable.builtin` using `#match?` predicates in `highlights.scm`, following the pattern from [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript/blob/master/queries/highlights.scm)
- Export the bundled highlights query for Go consumers via `go:embed` in a root-level `queries.go` with `GetLanguage()` and `GetHighlightsQuery()` helpers, following the pattern from [tree-sitter-familymarkup](https://github.com/redexp/tree-sitter-familymarkup)
- Add test verifying the highlights query compiles and contains the `variable.builtin` capture

## Test plan
- [x] All 61 tree-sitter corpus tests pass
- [x] Go binding test passes (`go test ./bindings/go/`)
- [x] New `TestHighlightsQueryCompiles` passes — verifies query compiles against grammar and `variable.builtin` capture exists
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added syntax highlighting for CMD environment variables (e.g., %CD%, %ERRORLEVEL%, %DATE%, %TIME%) and related builtin-like references.
  - Exposed a programmatic highlights-query interface for consumers to obtain compiled highlight rules.

* **Documentation**
  - Added usage guide and examples showing how to access the highlights query from code.

* **Tests**
  - Added tests ensuring the highlights query compiles and includes the expected capture names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->