### PR TITLE
fix: make Package.swift fully declarative for SPM compatibility

### DIFF
--- a/.github/workflows/swift-compat.yml
+++ b/.github/workflows/swift-compat.yml
@@ -1,0 +1,22 @@
+name: Swift Compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  swift-compat:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build Swift package
+        run: swift build
+
+      - name: Run Swift tests
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules/
 
 # Swift artifacts
 .build/
+.swiftpm/
+Package.resolved
 
 # Go artifacts
 _obj/

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,6 @@
 // swift-tools-version:5.3
 
-import Foundation
 import PackageDescription
-
-var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
 
 let package = Package(
     name: "TreeSitterBatch",
@@ -21,12 +15,48 @@ let package = Package(
             name: "TreeSitterBatch",
             dependencies: [],
             path: ".",
-            sources: sources,
+            exclude: [
+                ".editorconfig",
+                ".gitattributes",
+                ".github",
+                "binding.gyp",
+                "bindings/c",
+                "bindings/go",
+                "bindings/node",
+                "bindings/python",
+                "bindings/rust",
+                "Cargo.lock",
+                "Cargo.toml",
+                "CMakeLists.txt",
+                "eslint.config.mjs",
+                "examples",
+                "go-compat",
+                "go.mod",
+                "go.sum",
+                "grammar.js",
+                "LICENSE",
+                "Makefile",
+                "node_types.go",
+                "package-lock.json",
+                "package.json",
+                "pyproject.toml",
+                "queries.go",
+                "queries_test.go",
+                "README.md",
+                "setup.py",
+                "src/grammar.json",
+                "src/node-types.json",
+                "test",
+                "tree-sitter.json",
+            ],
+            sources: [
+                "src/parser.c",
+            ],
             resources: [
-                .copy("queries")
+                .copy("queries"),
             ],
             publicHeadersPath: "bindings/swift",
-            cSettings: [.headerSearchPath("src")]
+            cSettings: [.headerSearchPath("src")],
         ),
         .testTarget(
             name: "TreeSitterBatchTests",
@@ -34,8 +64,8 @@ let package = Package(
                 "SwiftTreeSitter",
                 "TreeSitterBatch",
             ],
-            path: "bindings/swift/TreeSitterBatchTests"
-        )
+            path: "bindings/swift/TreeSitterBatchTests",
+        ),
     ],
     cLanguageStandard: .c11
 )


### PR DESCRIPTION
## Summary
- Replace runtime `Foundation`/`FileManager.fileExists` check with explicit `exclude` list and static `sources` in `Package.swift`
- The dynamic approach can fail in sandboxed Xcode package resolution and non-Darwin SPM environments
- Add `.swiftpm/` and `Package.resolved` to `.gitignore`

Inspired by https://github.com/mdovale/tree-sitter-batch/commit/8e79050

## Test plan
- [ ] Verify `swift build` succeeds (requires Swift toolchain)
- [ ] Verify adding as SPM dependency in an Xcode project resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated Swift compatibility testing across Ubuntu and macOS platforms.
  * Streamlined Swift package configuration by removing conditional build logic and simplifying compilation targets.
  * Updated build artifact exclusions to keep the build environment clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->