### PR TITLE
chore: type-check grammar.js with tsc in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - grammar.js
       - eslint.config.mjs
+      - tsconfig.json
       - package.json
       - package-lock.json
       - .github/workflows/lint.yml
@@ -13,6 +14,7 @@ on:
     paths:
       - grammar.js
       - eslint.config.mjs
+      - tsconfig.json
       - package.json
       - package-lock.json
       - .github/workflows/lint.yml
@@ -32,3 +34,5 @@ jobs:
         run: npm ci
       - name: Run ESLint
         run: npm run lint
+      - name: Type-check grammar.js
+        run: npm run typecheck

--- a/grammar.js
+++ b/grammar.js
@@ -1,4 +1,9 @@
-const ci = (word) => new RegExp(word.split('').map((c) => /[a-zA-Z]/.test(c) ? `[${c.toLowerCase()}${c.toUpperCase()}]` : c).join(''));
+/// <reference types="tree-sitter-cli/dsl"/>
+// @ts-check
+
+/** @param {string} word */
+const ci = (word) => new RegExp(word.split('').map((/** @type {string} */ c) => /[a-zA-Z]/.test(c) ? `[${c.toLowerCase()}${c.toUpperCase()}]` : c).join(''));
+/** @param {string} word */
 const kw = (word) => token(prec(10, ci(word)));
 const varRefChoice = () => choice(
   seq('%%', /[$@a-zA-Z_][$@a-zA-Z0-9_.#()\[\]]*/, '%%'),
@@ -18,6 +23,7 @@ const varRefChoice = () => choice(
   seq('%', /\\[@a-zA-Z_0-9.]+/, '%'),
   seq('%', /"[^"%\r\n]+"/, '%'),
 );
+/** @param {GrammarSymbols<string>} $ */
 const operand = ($) => [
   $.cond_exec, $.pipe_stmt, $.redirect_stmt, $.call_stmt, $.cmd, $.parenthesized,
   $.variable_assignment, $.goto_stmt, $.exit_stmt, $.setlocal_stmt, $.endlocal_stmt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-batch",
-  "version": "0.2.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-batch",
-      "version": "0.2.0",
+      "version": "0.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,8 @@
         "globals": "^17.5.0",
         "prebuildify": "^6.0.1",
         "tree-sitter-cli": "0.26.8",
-        "tree-sitter-go-types": "^0.1.0"
+        "tree-sitter-go-types": "^0.1.0",
+        "typescript": "^6.0.3"
       },
       "peerDependencies": {
         "tree-sitter": ">=0.25.0"
@@ -1427,6 +1428,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "globals": "^17.5.0",
     "prebuildify": "^6.0.1",
     "tree-sitter-cli": "0.26.8",
-    "tree-sitter-go-types": "^0.1.0"
+    "tree-sitter-go-types": "^0.1.0",
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "eslint-plugin-jsdoc": "^62.9.0"
@@ -58,6 +59,7 @@
     "start": "tree-sitter playground",
     "generate": "tree-sitter generate --abi 14 && tree-sitter-go-types",
     "lint": "eslint grammar.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "node --test bindings/node/*_test.js"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "types": ["tree-sitter-cli/dsl"]
+  },
+  "include": ["grammar.js"]
+}


### PR DESCRIPTION
## Summary
- Add `/// <reference types="tree-sitter-cli/dsl"/>` + `// @ts-check` to `grammar.js` so editors and `tsc` validate DSL usage against the bundled types
- Add a minimal `tsconfig.json` (`allowJs`/`checkJs`/`noEmit`/`strict`, `types: ["tree-sitter-cli/dsl"]`, includes only `grammar.js`) and an `npm run typecheck` script
- Extend the Lint workflow to run `npm run typecheck` after ESLint, and add `tsconfig.json` to its path filters
- Add JSDoc `@param` types on `ci()`, `kw()`, and `operand()` to satisfy strict mode — no runtime behavior change, `src/parser.c` is unaffected

Adapts the pattern from wharflab/tree-sitter-powershell#23.

## Test plan
- [x] `npm run typecheck` passes locally (exit 0)
- [x] `npm run lint` still passes locally
- [ ] Lint workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)